### PR TITLE
Update Browser Support: Firefox supports conic-gradients()

### DIFF
--- a/src/slim/index.slim
+++ b/src/slim/index.slim
@@ -111,11 +111,9 @@ html lang="en"
 						.samsung.browser
 							img.browser-icon src="img/browsers/samsung.png" width="128" height="128" alt="Samsung browser icon"
 							| Samsung 10.1+
-					.browser-support.not-supported-by-default
-						h3 Not supported by default
 						.firefox.browser
 							img.browser-icon src="img/browsers/firefox.png" width="128" height="128" alt="Firefox icon"
-							| Firefox 75+
+							| Firefox 83+
 					.browser-support.not-supported
 						h3 Not supported
 						.ie.browser

--- a/src/slim/index.slim
+++ b/src/slim/index.slim
@@ -96,7 +96,7 @@ html lang="en"
 				.box.container
 					header
 						h2 Browser Support
-						p From <a href="https://caniuse.com/#feat=css-conic-gradients">Caniuse</a>. Updated 21 March 2020.
+						p From <a href="https://caniuse.com/#feat=css-conic-gradients">Caniuse</a>. Updated 12 December 2020.
 					.browser-support.supported
 						h3 Supported
 						.chrome.browser


### PR DESCRIPTION
Firefox 75-83 you could use the `conic-gradients()` under a flag.

Firefox 83 (released on Nov 17, 2020) added `conic-gradients()` support by default.